### PR TITLE
Fix ImportError by Pinning aiogram Version to 2.25.1 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-aiogram
+aiogram==2.25.1
 cryptocompare
 python-decouple
 redis


### PR DESCRIPTION
I encountered an issue where the project failed to start due to an ImportError related to the 'aiogram' library. After investigation, I found that the problem arises when using the latest version (3.0.0) of aiogram. However, version 2.25.1 works correctly.

This pull request addresses the issue by updating the 'aiogram' version in the requirements.txt file to 2.25.1, ensuring that the project can be successfully executed. The change is necessary to maintain the project's functionality until any compatibility issues with newer versions of aiogram are resolved.

I have tested this change locally, and it resolves the problem. Please review and consider merging this pull request to improve the project's reliability.

Thank you for maintaining this repository, and I hope this contribution is helpful.